### PR TITLE
Fix formatting in level_edge_distance

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -193,11 +193,11 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 
 ### Manual Level Points Edge distance (mm)
 # distance in mm, Feedrates in mm/min
-# Leveling Edge distance format  [pause_pos: X<distance in mm> Y<distance in mm>]
+# Leveling Edge distance format  [level_edge_distance: XY<position in mm>]
 # Leveling Z Position format     [level_z_pos: Z<position in mm>]
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
-level_edge_distance: X20 Y20
+level_edge_distance:20
 level_z_pos:0.2
 level_z_raise:10
 level_feedrate: X6000 Y6000 Z6000


### PR DESCRIPTION
config.ini formatting for "level_edge_distance" was incorrect. It's expecting a single number like "20" in current implementation and not something like "X20 Y20." Currently, the firmware will ignore it and make the nozzle go to X0 Y0 upon doing a lower left manual level command.